### PR TITLE
Small grammar and style fixes

### DIFF
--- a/docs/actor/input_schema.md
+++ b/docs/actor/input_schema.md
@@ -8,13 +8,13 @@ menuWeight: 3.5
 
 #### Specification version 1
 
-Actor input schema defines the input that actor accepts and the UI components used for input at Apify platform. Using input schema you can provide UI to actor users that is easy to use and also ensure that input of your actor is valid.
+Actor input schema defines the input that the actor accepts and the UI components used for input at the Apify platform. Using input schema, you can provide UI to actor users that is easy to use, and also ensure that the input of your actor is valid.
 
-Input schema must be stored in a file named `INPUT_SCHEMA.json` in the root directory of the actor. Maximum size of input schema file is 100 kB. If the input schema is provided then input is always validated to fulfill schema when an actor is being started (via API or from run console at Apify platform).
+Input schema must be stored in a file named `INPUT_SCHEMA.json` in the root directory of the actor. Maximum size of the input schema file is 100 kB. If the input schema is provided, then input is always validated to fulfill the schema when an actor is being started (via API or from a run console at the Apify platform).
 
 ## Example
 
-Imagine you are building a simple crawler whose inputs are an array of start URLs and javascript function that will be executed at each page crawler visits. Then the input schema will look as follows:
+Imagine you are building a simple crawler whose inputs are an array of start URLs and a Javascript function that will be executed at each page the crawler visits. Then the input schema will look as follows:
 
     {
         "title": "Cheerio Crawler input",
@@ -43,11 +43,11 @@ Imagine you are building a simple crawler whose inputs are an array of start URL
         "required": ["startUrls", "pageFunction"]
     }
 
-And generated input UI will be:
+And generated the input UI will be:
 
 ![Apify actor input schema example]({{@asset actor/images/input-schema-example.png}})
 
-If you switch input to **raw** display using a blue switcher then you will see entered input stringified to a JSON format as it will be passed to the actor:
+If you switch the input to **raw** display using the blue toggle, then you will see the entered input stringified to a JSON format as it will be passed to the actor:
 
     {
       "startUrls": [
@@ -63,22 +63,22 @@ If you switch input to **raw** display using a blue switcher then you will see e
 
 ## Structure
 
-Input schema is a JSON file named `INPUT_SCHEMA.json` in the root directory of an actor with the following structure:
+The input schema is a JSON file named `INPUT_SCHEMA.json`, placed in the root directory of an actor with the following structure:
 
     {
         "title": "Cheerio Crawler input",
         "type": "object",
         "schemaVersion": 1,
-        "properties": { /* here is a place for definition of input fields */ },
+        "properties": { /* here is a place for the definition of input fields */ },
         "required": []
     }
 
 |Property|Type|Required|Description|
 |--- |--- |--- |--- |
 |`title`|String|Yes|Any text describing your input schema.|
-|`description`|String|No|Help text for input that will be displayed above the UI fields.|
-|`type`|String|Yes|This is fixed and must be set to string `object`|
-|`schemaVersion`|Integer|Yes|The version of input schema specification against your schema is written. Currently, only version `1` is out.|
+|`description`|String|No|Help text for the input that will be displayed above the UI fields.|
+|`type`|String|Yes|This is fixed and must be set to string `object`.|
+|`schemaVersion`|Integer|Yes|The version of the input schema specification against which your schema is written. Currently, only version `1` is out.|
 |`properties`|Object|Yes|This is an object mapping each field key to its specification.|
 |`required`|[String]|No|An array of field keys that are required.|
 
@@ -94,17 +94,17 @@ Each field of your input is described under its key in `inputSchema.properties` 
 |`default`|Must match `type` property.|No|Default value that will be used when no value is provided.|
 |`prefill`|Must match `type` property.|No|Value that will be prefilled in the actor input interface. Only the `boolean` type doesn't support `prefill` property.|
 |`example`|Must match `type` property.|No|Sample value of this field for the actor to be displayed when actor is published in Apify Store.|
-|`sectionCaption`|String|No|If this property is set then all fields following this field (this field included) will be separated into a collapsible section with the value set as it's caption. The section ends at the last field or next field which has `sectionCaption` property set.|
-|`sectionDescription`|String|No|If `sectionCaption` property is set, then you can use this property to provide additional description to the section. The description will be visible right under the caption when the section is open.|
+|`sectionCaption`|String|No|If this property is set, then all fields following this field (this field included) will be separated into a collapsible section with the value set as its caption. The section ends at the last field or the next field which has `sectionCaption` property set.|
+|`sectionDescription`|String|No|If the `sectionCaption` property is set, then you can use this property to provide additional description to the section. The description will be visible right under the caption when the section is open.|
 
 
 ### Additional properties
 
-In addition to that properties listed above, most of the types support also additional properties defining, for example, UI input editor.
+In addition to the properties listed above, most of the types support also additional properties defining, for example, the UI input editor.
 
 #### String
 
-Example of code input:
+Example of a code input:
 
     {
         "title": "Page function",
@@ -118,7 +118,7 @@ Rendered input:
 
 ![Apify actor input schema page function]({{@asset actor/images/input-schema-page-function.png}})
 
-Example of country selection using select input:
+Example of country selection using a select input:
 
     {
         "title": "Country",
@@ -138,13 +138,13 @@ Properties:
 
 |Property|Value|Required|Description|
 |--- |--- |--- |--- |
-|`editor`|One of `json`, `textfield`, `textarea`, `javascript`, `select`, `hidden`|Yes|Visual editor used for input field.|
-|`pattern`|String|No|Regular expression that will be used to validate the input|
-|`minLength`|Integer|No|Minimum length of the string|
-|`maxLength`|Integer|No|Maximum length of the string|
-|`enum`|[String]|Required if editor is `select`|Using this field you can limit values to the given array se of strings. Input will be displayed as select box.|
-|`enumTitles`|[String]|No|Titles for the `enum` keys described|
-|`nullable`|Boolean|No|Specifies whether null is an allowed value|
+|`editor`|One of `json`, `textfield`, `textarea`, `javascript`, `select`, `hidden`|Yes|Visual editor used for the input field.|
+|`pattern`|String|No|Regular expression that will be used to validate the input.|
+|`minLength`|Integer|No|Minimum length of the string.|
+|`maxLength`|Integer|No|Maximum length of the string.|
+|`enum`|[String]|Required if `editor` is `select`|Using this field, you can limit values to the given array of strings. Input will be displayed as select box.|
+|`enumTitles`|[String]|No|Titles for the `enum` keys described.|
+|`nullable`|Boolean|No|Specifies whether `null` is an allowed value.|
 
 
 #### Boolean
@@ -178,10 +178,10 @@ Properties:
 
 |Property|Value|Required|Description|
 |--- |--- |--- |--- |
-|`editor`|One of `checkbox`, `hidden`|no|Visual editor used for input field.|
-|`groupCaption`|String|No|If you want to group multiple checkboxes together add this option to the first one.|
+|`editor`|One of `checkbox`, `hidden`|No|Visual editor used for the input field.|
+|`groupCaption`|String|No|If you want to group multiple checkboxes together, add this option to the first of the group.|
 |`groupDescription`|String|No|Description displayed as help text displayed of group title.|
-|`nullable`|Boolean|No|Specifies whether null is an allowed value|
+|`nullable`|Boolean|No|Specifies whether null is an allowed value.|
 
 #### Integer
 
@@ -204,11 +204,11 @@ Properties:
 
 |Property|Value|Required|Description|
 |--- |--- |--- |--- |
-|`editor`|One of `number`, `hidden`|no|Visual editor used for input field.|
+|`editor`|One of `number`, `hidden`|No|Visual editor used for input field.|
 |`maximum`|Integer|No|Maximum allowed value.|
-|`minimum`|Integer|No|Minimum allowed value|
-|`unit`|String>|No|Unit displayed next to the field in UI. For example second, MB, etc.|
-|`nullable`|Boolean|No|Specifies whether null is an allowed value|
+|`minimum`|Integer|No|Minimum allowed value.|
+|`unit`|String|No|Unit displayed next to the field in UI, for example _second_, _MB_, etc.|
+|`nullable`|Boolean|No|Specifies whether null is an allowed value.|
 
 #### Object
 
@@ -226,21 +226,21 @@ Rendered input:
 
 ![Apify actor input schema proxy]({{@asset actor/images/input-schema-proxy.png}})
 
-The object where proxy configuration is stored has the following structure:
+The object where the proxy configuration is stored has the following structure:
 
     {
         // Indicates whether Apify Proxy was selected.
         "useApifyProxy": Boolean,
 
         // Array of Apify Proxy groups. Is missing or null if Apify Proxy's
-        // automatic mode was selected or proxies are not used.
+        // automatic mode was selected or if proxies are not used.
         "apifyProxyGroups": String[],
 
         // Array of custom proxy URLs. Is missing or null if custom proxies were not used.
         "proxyUrls": String[],
     }
 
-Example of an blackbox object:
+Example of a blackbox object:
 
     {
         "title": "User object",
@@ -259,11 +259,11 @@ Properties:
 |Property|Value|Required|Description|
 |--- |--- |--- |--- |
 |`editor`|One of `json`, `proxy`, `hidden`|Yes|UI editor used for input.|
-|`patternKey`|String|No|Regular expression that will be used to validate the keys of the object|
-|`patternValue`|String|No|Regular expression that will be used to validate the values of object|
-|`maxProperties`|Integer|No|Maximum number of properties the object can have|
-|`minProperties`|Integer|No|Minimum number of properties the object can have|
-|`nullable`|Boolean|No|Specifies whether null is an allowed value|
+|`patternKey`|String|No|Regular expression that will be used to validate the keys of the object.|
+|`patternValue`|String|No|Regular expression that will be used to validate the values of object.|
+|`maxProperties`|Integer|No|Maximum number of properties the object can have.|
+|`minProperties`|Integer|No|Minimum number of properties the object can have.|
+|`nullable`|Boolean|No|Specifies whether null is an allowed value.|
 
 
 ### Array
@@ -307,12 +307,12 @@ Properties:
 |`patternValue`|String|No|Regular expression that will be used to validate the values of items in the array. Works only with `keyValue` and `stringList` editors.|
 |`maxItems`|Integer|No|Maximum number of items the array can contain.|
 |`minItems`|Integer|No|Minimum number of items the array can contain.|
-|`uniqueItems`|Boolean|No|Specifies whether the array should contain only unique values|
-|`nullable`|Boolean|No|Specifies whether null is an allowed value|
+|`uniqueItems`|Boolean|No|Specifies whether the array should contain only unique values.|
+|`nullable`|Boolean|No|Specifies whether null is an allowed value.|
 
 
 Usage of this field is based on the selected editor:
 
 *   `requestListSources` - value from this field can be used as input of [RequestList](https://sdk.apify.com/docs/api/requestlist) class from Apify SDK.
-*   `pseudoUrls` - is intended to be used with combination of [PseudoUrl](https://sdk.apify.com/docs/api/pseudourl) class and [Apify.utils.puppeteer.enqueueLinks()](https://sdk.apify.com/docs/api/puppeteer#puppeteer.enqueueLinks) function from Apify SDK.
+*   `pseudoUrls` - is intended to be used with a combination of the [PseudoUrl](https://sdk.apify.com/docs/api/pseudourl) class and the [Apify.utils.puppeteer.enqueueLinks()](https://sdk.apify.com/docs/api/puppeteer#puppeteer.enqueueLinks) function from the Apify SDK.
 

--- a/docs/actor/run.md
+++ b/docs/actor/run.md
@@ -149,5 +149,5 @@ The following example demonstrates how to start a simple web server in your acto
 
 ## [](#data-retention)Data retention
 
-Actor run gets deleted along with its default storages (key-value store, dataset, request queue) after a data retention period which is based on [subscription plan](https://apify.com/pricing) of a user.
+Actor run gets deleted along with its default storages (key-value store, dataset, request queue) after a data retention period which is based on [the subscription plan](https://apify.com/pricing) of a user.
 

--- a/docs/actor/run.md
+++ b/docs/actor/run.md
@@ -149,5 +149,5 @@ The following example demonstrates how to start a simple web server in your acto
 
 ## [](#data-retention)Data retention
 
-Actor run gets deleted along with its default storages (key-value store, dataset, request queue) after a data retention period which is based on [the subscription plan](https://apify.com/pricing) of a user.
+Actor run gets deleted along with its default storages (key-value store, dataset, request queue) after a data retention period which is based on the [subscription plan](https://apify.com/pricing) of a user.
 

--- a/docs/actor/source_code.md
+++ b/docs/actor/source_code.md
@@ -79,7 +79,7 @@ Internally, Apify uses Docker to build and run actors. To control the build of t
     COPY . ./
 
     # Install NPM packages, skip optional and development dependencies to keep the image small,
-    # avoid logging to much and show log the dependency tree
+    # avoid logging too much, and log the dependency tree
     RUN npm install --quiet --only=prod --no-optional \
      && npm list
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -6,7 +6,7 @@ menuWeight: 5
 
 # [](./scheduler)Scheduler
 
-[Schedules](https://my.apify.com/schedules) are used to automatically start your actors at certain times. Each schedule can be associated with a number of actors and actor tasks and it is also possible to override the settings of each actor (task) in a similar fashion as when invoking the actor (task) using the API.
+[Schedules](https://my.apify.com/schedules) are used to automatically start your actors at certain times. Each schedule can be associated with a number of actors and actor tasks, and it is also possible to override the settings of each actor (task) in a similar fashion as when invoking the actor (task) using the API.
 
 The schedules use [cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression) to specify the times of the run. The expression has the following structure:
 
@@ -21,18 +21,18 @@ The schedules use [cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_exp
 
 Note that all dates and times in the cron expression are always assumed to be in the UTC time zone. The minimum interval between runs is 10 seconds; if your next run is scheduled sooner than 10 seconds after the previous run, the next run will be skipped.
 
-Examples:  
-`0 8 * * *` every day at 8am  
-`0 0 * * 0` every 7 days (at 00:00 on Sunday)  
-`*/3 * * * *` every 3rd minute  
-`0 0 1 */2 *` every other month (at 00:00 on the first day of month, every 2nd month)
+## Examples:
+- `0 8 * * *` every day at 8am
+- `0 0 * * 0` every 7 days (at 00:00 on Sunday)
+- `*/3 * * * *` every 3rd minute
+- `0 0 1 */2 *` every other month (at 00:00 on the first day of month, every 2nd month)
 
-Additionally, you can use the following shortcut expressions:  
-`@yearly` (`0 0 1 1 *`)  
-`@monthly` (`0 0 1 * *`)  
-`@weekly` (`0 0 * * 0`)  
-`@daily` (`0 0 * * *`)  
-`@hourly` (`0 * * * *`)
+Additionally, you can use the following shortcut expressions:
+- `@yearly` (`0 0 1 1 *`)
+- `@monthly` (`0 0 1 * *`)
+- `@weekly` (`0 0 * * 0`)
+- `@daily` (`0 0 * * *`)
+- `@hourly` (`0 * * * *`)
 
 You can find more information and examples of cron expressions on [crontab.guru](http://crontab.guru/).
 

--- a/docs/webhooks/ad_hoc_webhooks.md
+++ b/docs/webhooks/ad_hoc_webhooks.md
@@ -6,7 +6,7 @@ menuWeight: 8.3
 
 # [](./webhooks#adhoc)Ad hoc webhooks
 
-An ad hoc webhook is a one-time webhook created for a certain actor run when starting the run using Apify [API](https://docs.apify.com/api/v2). It's triggered at most once when the given run transitions into the selected state. Ad hoc webhooks can be defined using a URL parameter `webhooks` added to the API endpoint that starts an actor or actor task:
+An ad hoc webhook is a one-time webhook created for a certain actor run when starting the run using the Apify [API](https://docs.apify.com/api/v2). It's triggered at most once when the given run transitions into the desired state. Ad hoc webhooks can be defined using an URL parameter `webhooks` added to the API endpoint that starts an actor or actor task:
 
     https://api.apify.com/v2/acts/[ACTOR_ID]/runs?token=[YOUR_API_TOKEN]&webhooks=[AD_HOC_WEBHOOKS]
 
@@ -26,16 +26,16 @@ where `AD_HOC_WEBHOOKS` is a base64 encoded stringified JSON array of webhook de
 
 ## Creating an ad hoc webhook dynamically
 
-You can also create a webhook dynamically from a code of your actor using `Apify.addWebhook()` function:
+You can also create a webhook dynamically from the code of your actor using the `Apify.addWebhook()` function:
 
     await Apify.addWebhook({
         eventTypes: ['ACTOR.RUN.CREATED'],
         requestUrl: 'https://example.com/run-created'
     });
 
-To learn more see [Apify SDK documentation](https://sdk.apify.com/docs/api/apify#apifyaddwebhook-code-promise-lt-object-undefined-gt-code).
+To learn more, see the [Apify SDK documentation](https://sdk.apify.com/docs/api/apify#apifyaddwebhook-code-promise-lt-object-undefined-gt-code).
 
-To ensure that duplicate ad hoc webhooks won't get created in a case of actor restart you can use `idempotencyKey` parameter. Idempotency key must be unique across all the webhooks of a user so the only one webhook gets created for a given value. You can use for example actor run ID as idempotency key:
+To ensure that duplicate ad hoc webhooks won't get created in a case of actor restart you can use the `idempotencyKey` parameter. The idempotency key must be unique across all the webhooks of a user so that only one webhook gets created for a given value. You can use, for example, the actor run ID as idempotency key:
 
     await Apify.addWebhook({
         eventTypes: ['ACTOR.RUN.CREATED'],

--- a/docs/webhooks/events.md
+++ b/docs/webhooks/events.md
@@ -17,16 +17,16 @@ Actor run events are triggered when an actor run gets created or transitions int
 ### Event types:
 
 *   `ACTOR.RUN.CREATED` - New actor run has been created.
-*   `ACTOR.RUN.SUCCEEDED` - Actor run finished with status `SUCCEEDED`
-*   `ACTOR.RUN.FAILED` - Actor run finished with status `FAILED`
-*   `ACTOR.RUN.ABORTED` - Actor run finished with status `ABORTED`
-*   `ACTOR.RUN.TIMED_OUT` - Actor run finished with status `TIMED-OUT`
+*   `ACTOR.RUN.SUCCEEDED` - Actor run finished with status `SUCCEEDED`.
+*   `ACTOR.RUN.FAILED` - Actor run finished with status `FAILED`.
+*   `ACTOR.RUN.ABORTED` - Actor run finished with status `ABORTED`.
+*   `ACTOR.RUN.TIMED_OUT` - Actor run finished with status `TIMED-OUT`.
 
 ### Event data:
 
     {
         "actorId": "ID of the triggering actor.",
         "actorTaskId": "If task was used, its ID.",
-        "actorRunId": "Id of the triggering actor run.",
+        "actorRunId": "ID of the triggering actor run.",
     }
 


### PR DESCRIPTION
I've been getting to know the Apify app over Christmas, before I joined Apify, in order to get to know the platform so I'm not completely lost when I join. I've been reading the user documentation for using the app, and I found some small stylistic issues, grammar issues (mostly missing articles), typos and such. Here I've tried to fix what I noticed, but I haven't gone through the whole documentation systematically, so this is nowhere near a comprehensive fix, just small improvements.