### PR TITLE
Proxy: Hotfix Connection settings table

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -11,9 +11,9 @@ Apify Proxy provides access to Apify's proxy services that can be used in [actor
 You can view your Apify Proxy settings on the [Proxy page](https://my.apify.com/proxy) in the app.
 
 
+*   [**Connection settings**]({{@link proxy/connection_settings.md}})
 *   [**Datacenter proxy**]({{@link proxy/datacenter_proxy.md}})
 *   [**Residential proxy**]({{@link proxy/residential_proxy.md}})
 *   [**Google SERP proxy**]({{@link proxy/google_serp_proxy.md}})
-*   [**Connection_settings**]({{@link proxy/connection_settings.md}})
-*   [**troubleshooting**]({{@link proxy/troubleshooting.md}})
+*   [**Troubleshooting**]({{@link proxy/troubleshooting.md}})
 

--- a/docs/proxy/connection_settings.md
+++ b/docs/proxy/connection_settings.md
@@ -6,17 +6,16 @@ menuWeight: 7.1
 
 # [](#connection-settings)Connection settings
 
-The following table shows HTTP proxy connection settings for the Apify Proxy.
+The following table shows the HTTP proxy connection settings for the Apify Proxy.
 
-|Proxy type|
-|--- |
-|`HTTP`|
-|`proxy.apify.com`|
-|`8000`|
-|Specifies proxy settings. See [username parameters]({{@link proxy/datacenter_proxy.md#username-parameters}}) below for details. **Beware that this is not your Apify username!**|
-|Proxy password. Your password is displayed on the [Proxy page](https://my.apify.com/proxy) in the app. Also, in Apify actors, it is passed as the `APIFY_PROXY_PASSWORD` environment variable. See [actor documentation]({{@link actor/run.md#run-env-vars}}) for more details.|
-|`http://:@proxy.apify.com:8000`|
+| Parameter      | Value / explanation |
+|----------------|---------------------|
+| Proxy type     | `HTTP`              |
+| Hostname       | `proxy.apify.com`   |
+| Port           | `8000`              |
+| Username       | Specifies the proxy parameters. See [username parameters]({{@link proxy/datacenter_proxy.md#username-parameters}}) below for details. **Beware that this is not your Apify username!** |
+| Password       | Proxy password. Your password is displayed on the [Proxy page](https://my.apify.com/proxy) in the app. Also, in Apify actors, it is passed as the `APIFY_PROXY_PASSWORD` environment variable. See [actor documentation]({{@link actor/run.md#run-env-vars}}) for more details. |
+| Connection URL | `http://<username>:<password>@proxy.apify.com:8000`|
 
 
 **WARNING:** All usage of Apify Proxy with your password is charged towards your account. Do not share the password with untrusted parties or use it from insecure networks, because the password is sent unencrypted due to the limitations of the HTTP protocol.
-


### PR DESCRIPTION
The proxy connection settings table was broken, this hotfixes that.
This also fixes the link text on the proxy overview.

This PR just does some hotfixes so the docs are not broken, but the Connection Settings page could maybe use a bit more work, like explaining the username parameter better.